### PR TITLE
docs: added CODEOWNERS & PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ITByteOrg/admin

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Title: [Brief, descriptive title of the PR]
+
+### Description
+- What does this PR do?
+- Why is this change needed?
+- Any relevant background information?
+### Changes Made
+- List key changes in bullet points
+### Issue Reference
+- Closes #[Issue Number] (if applicable)
+- NA
+### Testing
+- Steps to test the changes
+- Expected results
+- NA
+### Checklist
+- [ ] Code follows project guidelines
+- [ ] Tests added or updated
+- [ ] Documentation updated (if needed)


### PR DESCRIPTION
Setting up some lightweight governance:

- Added `.github/CODEOWNERS` so review requests go to the right people automatically
- Dropped in a basic PR template to make pull request descriptions more consistent
- Meant to help streamline reviews and keep things clean as the repo opens up

